### PR TITLE
Use html.escape() instead of cgi.escape()

### DIFF
--- a/mush.py
+++ b/mush.py
@@ -2,7 +2,7 @@ from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 import json
 import diggerconf
-from cgi import escape
+from html import escape
 
 # MUSH-related functions and variables
 


### PR DESCRIPTION
`cgi.escape()` generates a DeprecationWarning. This change removes the deprecated code, using the recommended replacement code in its place.